### PR TITLE
Made outputName, name and description configurable

### DIFF
--- a/src/main/java/org/tomdz/maven/sphinx/SphinxMojo.java
+++ b/src/main/java/org/tomdz/maven/sphinx/SphinxMojo.java
@@ -6,9 +6,11 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
+
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
@@ -50,6 +52,30 @@ public class SphinxMojo extends AbstractMavenReport
      * @required
      */
     private File outputDirectory;
+    
+    /**
+     * Name of the report.
+     *
+     * @parameter expression="Documentation via sphinx"
+     * @required
+     */
+    private String name;
+    
+    /**
+     * Description of the report.
+     *
+     * @parameter expression="Documentation via sphinx"
+     * @required
+     */
+    private String description;
+    
+    /**
+     * The base name used to create report's output file(s).
+     *
+     * @parameter expression="index"
+     * @required
+     */
+    private String outputName;
 
     /**
      * The directory for sphinx' source.
@@ -99,19 +125,19 @@ public class SphinxMojo extends AbstractMavenReport
     @Override
     public String getDescription(Locale defaultLocale)
     {
-        return "Documentation via sphinx";
+        return description;
     }
 
     @Override
     public String getName(Locale defaultLocale)
     {
-        return "Documentation via sphinx";
+        return name;
     }
 
     @Override
     public String getOutputName()
     {
-        return "index";
+        return outputName;
     }
 
     @Override

--- a/src/site/sphinx/configuration.rst
+++ b/src/site/sphinx/configuration.rst
@@ -13,6 +13,9 @@ Parameter            Description                                                
 ==================== ================================================================================================= ========================================
 ``sourceDirectory``  The directory containing the documentation source.                                                ``${basedir}/src/site/sphinx``
 ``outputDirectory``  The directory where the generated output will be placed.                                          ``${project.reporting.outputDirectory}``
+``outputName``       The base name used to create report's output file(s).                                             ``index``
+``name``             The name of the report.                                                                           ``Documentation via sphinx``
+``description``      The description of the report.                                                                    ``Documentation via sphinx``
 ``builder``          The builder to use. See the `Sphinx commandline documentation`_ for a list of possible builders.  ``html``
 ``verbose``          Whether Sphinx should generate verbose output.                                                    ``true``
 ``warningsAsErrors`` Whether warnings should be treated as errors.                                                     ``false``


### PR DESCRIPTION
Hi Thomas,

Thank you for creating this plugin, it will most likely be a great help for me in the future :-)

I extended the configuration a bit, i.e. I made outputName, name and description configurable, and I also updated the documentation accordingly. The outputName is important for me because I don't want the plugin to overwrite the default index.html, and the name and description can now be configured as the user likes.

I would be very happy if you could merge this change into your cade and release a version 1.0.3 of the plugin soon :-)

Cheers,

Michael
